### PR TITLE
Heartbeat

### DIFF
--- a/django_stomp/builder.py
+++ b/django_stomp/builder.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from django.conf import settings
 from django_stomp.helpers import clean_dict_with_falsy_or_strange_values
+from django_stomp.helpers import eval_as_int_otherwise_none
 from django_stomp.helpers import eval_str_as_boolean
 from django_stomp.services import consumer
 from django_stomp.services import producer
@@ -33,16 +34,18 @@ def build_listener(
 
 
 def _build_connection_parameter(client_id: Optional[str] = None) -> Dict:
-    stomp_server_port = getattr(settings, "STOMP_SERVER_PORT", None)
-    stomp_server_port = int(stomp_server_port) if stomp_server_port else None
-    stomp_server_standby_port = getattr(settings, "STOMP_SERVER_STANDBY_PORT", None)
-    stomp_server_standby_port = int(stomp_server_standby_port) if stomp_server_standby_port else None
+    stomp_server_port = eval_as_int_otherwise_none(getattr(settings, "STOMP_SERVER_PORT", None))
+    stomp_server_standby_port = eval_as_int_otherwise_none(getattr(settings, "STOMP_SERVER_STANDBY_PORT", None))
+    outgoing_heartbeat = eval_as_int_otherwise_none(getattr(settings, "STOMP_OUTGOING_HEARTBIT", None))
+    incoming_heartbeat = eval_as_int_otherwise_none(getattr(settings, "STOMP_INCOMING_HEARTBIT", None))
 
     required_params = {
         "host": getattr(settings, "STOMP_SERVER_HOST", None),
         "port": stomp_server_port,
         "hostStandby": getattr(settings, "STOMP_SERVER_STANDBY_HOST", None),
         "portStandby": stomp_server_standby_port,
+        "outgoingHeartbeat": outgoing_heartbeat,
+        "incomingHeartbeat": incoming_heartbeat,
     }
 
     logger.debug("Server details connection: %s", required_params)

--- a/django_stomp/helpers.py
+++ b/django_stomp/helpers.py
@@ -37,3 +37,7 @@ def return_none_if_provided_value_is_falsy_or_strange(value):
 
 def clean_dict_with_falsy_or_strange_values(value: Dict) -> Dict:
     return {k: v for k, v in value.items() if return_none_if_provided_value_is_falsy_or_strange(v)}
+
+
+def eval_as_int_otherwise_none(value):
+    return int(value) if value else None

--- a/django_stomp/services/consumer.py
+++ b/django_stomp/services/consumer.py
@@ -120,8 +120,13 @@ def build_listener(
     use_ssl = connection_params.get("use_ssl", False)
     ssl_version = connection_params.get("ssl_version", ssl.PROTOCOL_TLS)
     logger.info(f"Use SSL? {use_ssl}. Version: {ssl_version}")
+    outgoing_heartbeat = int(connection_params.get("outgoingHeartbeat", 60000))
+    incoming_heartbeat = int(connection_params.get("incomingHeartbeat", 60000))
     # http://stomp.github.io/stomp-specification-1.2.html#Heart-beating
-    conn = stomp.Connection(hosts, ssl_version=ssl_version, use_ssl=use_ssl)
+    # http://jasonrbriggs.github.io/stomp.py/api.html
+    conn = stomp.Connection(
+        hosts, ssl_version=ssl_version, use_ssl=use_ssl, heartbeats=(outgoing_heartbeat, incoming_heartbeat)
+    )
     client_id = connection_params.get("client_id", uuid.uuid4())
     subscription_configuration = {"destination": destination_name, "ack": ack_type.value}
     header_setup = {"client-id": f"{client_id}-listener", "activemq.prefetchSize": "1"}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="django_stomp",
-    version="0.0.22",
+    version="0.0.23",
     description="A simple implementation of STOMP with Django",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,38 +23,4 @@ def pytest_configure():
         STOMP_SERVER_PASSWORD=os.getenv("STOMP_SERVER_PASSWORD"),
         STOMP_USE_SSL=os.getenv("STOMP_USE_SSL"),
         STOMP_LISTENER_CLIENT_ID=os.getenv("STOMP_LISTENER_CLIENT_ID"),
-        LOGGING={
-            "version": 1,
-            "disable_existing_loggers": False,
-            "formatters": {
-                "standard": {"()": Formatter, "format": "%(asctime)s - level=%(levelname)s - %(name)s - %(message)s"}
-            },
-            "handlers": {
-                "console": {"class": "logging.StreamHandler", "formatter": os.getenv("LOG_FORMATTER", "standard")}
-            },
-            "loggers": {
-                "": {"level": os.getenv("ROOT_LOG_LEVEL", "INFO"), "handlers": ["console"]},
-                "django": {"level": os.getenv("DJANGO_LOG_LEVEL", "INFO"), "propagate": False, "handlers": ["console"]},
-                "django.request": {
-                    "level": os.getenv("DJANGO_REQUEST_LOG_LEVEL", "INFO"),
-                    "handlers": ["console"],
-                    "propagate": False,
-                },
-                "django.db.backends": {
-                    "level": os.getenv("DJANGO_DB_BACKENDS_LOG_LEVEL", "INFO"),
-                    "propagate": False,
-                    "handlers": ["console"],
-                },
-                "stomp.py": {
-                    "level": os.getenv("STOMP_LOG_LEVEL", "DEBUG"),
-                    "handlers": ["console"],
-                    "propagate": False,
-                },
-                "django_stomp": {
-                    "level": os.getenv("DJANGO_STOMP_LEVEL", "DEBUG"),
-                    "handlers": ["console"],
-                    "propagate": False,
-                },
-            },
-        },
     )

--- a/tests/integration/test_execution.py
+++ b/tests/integration/test_execution.py
@@ -287,6 +287,10 @@ def test_should_use_heartbeat_and_then_lost_connection_due_message_takes_longer_
     _test_callback_function_with_sleep_three_seconds function) which takes longer to process than the
     heartbeat time of 1 second (1000); resulting in a heartbeat timeout when
     a message is received, and a subsequent disconnect.
+
+    Heartbeating requires an error margin due to timing inaccuracies which are usually configured
+    by the receiver (such as the broker and even the client). Thus, other brokers may wait for a little bit more
+    or less before considering the connection dead.
     """
     caplog.set_level(logging.DEBUG)
     some_destination = f"some-lorem-destination-{uuid.uuid4()}"


### PR DESCRIPTION
We've been using `django-stomp` without hearbeat so far, but it changes now, the main purpose to have it is because it must handle ACTIVE/STANDBY brokers, that is, if the STANDBY turns out to ACTIVE and the ACTIVE to STANDBY then django-stomp must properly connect to the switched broker.

More details about how heartbeat works:

- https://stomp.github.io/stomp-specification-1.2.html#Heart-beating
- https://github.com/jasonrbriggs/stomp.py/issues/129#issuecomment-277852826
- http://jasonrbriggs.github.io/stomp.py/api.html