### PR TITLE
Added new option to process message on background

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ subscription in ActiveMQ.
     
   A flag that indicates if `correlation-id` header must be required or not. By default this flag is true (good practice 
 thinking in future troubleshooting). 
-  Set to ``False, false, 0, F, f, N or n`` in order to allow consume messages without `correlation-id` header. If it's 
+Set to ``False, false, 0, F, f, N or n`` in order to allow consume messages without `correlation-id` header. If it's 
 false `django-stomp` generates a correlation-id header for the message automatically.
 
 ***STOMP_PROCESS_MSG_ON_BACKGROUND***

--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ false `django-stomp` generates a correlation-id header for the message automatic
 to still take place.
   Set to ``True, true, 1, T, t, Y or y`` in order to have the message processing on background.
 
+***STOMP_PROCESS_MSG_WORKERS***
+
+  Optional parameter that controls how many workers the pool that manage the background processing should create. If
+defined, this parameter **must** be an integer!
+
 ## Tests
 
 In order to execute tests for ActiveMQ, execute the following:

--- a/README.md
+++ b/README.md
@@ -135,10 +135,16 @@ subscription in ActiveMQ.
 
 ***STOMP_CORRELATION_ID_REQUIRED***
     
- A flag that indicates if `correlation-id` header must be required or not. By default this flag is true (good practice 
+  A flag that indicates if `correlation-id` header must be required or not. By default this flag is true (good practice 
 thinking in future troubleshooting). 
-Set to ``False, false, 0, F, f, N or n`` in order to allow consume messages without `correlation-id` header. If it's 
+  Set to ``False, false, 0, F, f, N or n`` in order to allow consume messages without `correlation-id` header. If it's 
 false `django-stomp` generates a correlation-id header for the message automatically.
+
+***STOMP_PROCESS_MSG_ON_BACKGROUND***
+
+  A flag to indicate if it should process a received message on background, enabling the broker-consumer communication 
+to still take place.
+  Set to ``True, true, 1, T, t, Y or y`` in order to have the message processing on background.
 
 ## Tests
 
@@ -160,6 +166,7 @@ Then at last:
 * Currently, we assume that all dead lettered messages are sent to a queue with the same name as its original 
 destination but prefixed with `DLQ.`, i.e., if your queue is `/queue/some-queue`, the dead letter destination is 
 asssumed to be `/queue/DLQ.some-queue`.
-* Be cautious with the heartbeat functionality! If your consumer is slow, it could prevent the client to receive and 
-process any `heart-beat` frame sent by the server, causing the client to terminate the connection due to a false 
-positive heartbeat timeout.
+* **Be cautious with the heartbeat functionality**! If your consumer is slow, it could prevent the client to receive 
+and process any `heart-beat` frame sent by the server, causing the client to terminate the connection due to a false 
+positive heartbeat timeout. You can workaround it with the `STOMP_PROCESS_MSG_ON_BACKGROUND` parameter that uses a
+thread pool to process the message.

--- a/README.md
+++ b/README.md
@@ -109,13 +109,14 @@ Here is a list of parameters that you can set in your Django project settings:
   A positive integer to indicates what is the period (in milliseconds) the client will send a frame to the server 
 that indicates its still alive. Set to ``0`` to means that it cannot send any heart-beat frame. See the [STOMP 
 protocol specification](https://stomp.github.io/stomp-specification-1.1.html#Heart-beating) for more information.
+Defaults to 6000 ms.
 
 ***STOMP_INCOMING_HEARTBIT***
     
   A positive integer to indicates what is the period (in milliseconds) the client will await for a server frame until 
 it assumes that the server is still alive. Set to ``0`` to means that it do not want to receive heart-beats. See 
 the [STOMP protocol specification](https://stomp.github.io/stomp-specification-1.1.html#Heart-beating) for more 
-information.
+information. Defaults to 6000 ms.
 
 ***STOMP_WAIT_TO_CONNECT***
     

--- a/django_stomp/builder.py
+++ b/django_stomp/builder.py
@@ -3,6 +3,7 @@ from typing import Dict
 from typing import Optional
 
 from django.conf import settings
+
 from django_stomp.helpers import clean_dict_with_falsy_or_strange_values
 from django_stomp.helpers import eval_as_int_otherwise_none
 from django_stomp.helpers import eval_str_as_boolean
@@ -23,6 +24,7 @@ def build_publisher(client_id: Optional[str] = None) -> Publisher:
 def build_listener(
     destination_name: str,
     durable_topic_subscription: bool = False,
+    should_process_msg_on_background: bool = False,
     is_testing: bool = False,
     client_id: Optional[str] = None,
     routing_key: Optional[str] = None,
@@ -34,6 +36,7 @@ def build_listener(
         durable_topic_subscription=durable_topic_subscription,
         is_testing=is_testing,
         routing_key=routing_key,
+        should_process_msg_on_background=should_process_msg_on_background,
         **connection_params,
     )
 

--- a/django_stomp/builder.py
+++ b/django_stomp/builder.py
@@ -3,7 +3,6 @@ from typing import Dict
 from typing import Optional
 
 from django.conf import settings
-
 from django_stomp.helpers import clean_dict_with_falsy_or_strange_values
 from django_stomp.helpers import eval_as_int_otherwise_none
 from django_stomp.helpers import eval_str_as_boolean
@@ -44,8 +43,8 @@ def build_listener(
 def _build_connection_parameter(client_id: Optional[str] = None) -> Dict:
     stomp_server_port = eval_as_int_otherwise_none(getattr(settings, "STOMP_SERVER_PORT", None))
     stomp_server_standby_port = eval_as_int_otherwise_none(getattr(settings, "STOMP_SERVER_STANDBY_PORT", None))
-    outgoing_heartbeat = eval_as_int_otherwise_none(getattr(settings, "STOMP_OUTGOING_HEARTBIT", None))
-    incoming_heartbeat = eval_as_int_otherwise_none(getattr(settings, "STOMP_INCOMING_HEARTBIT", None))
+    outgoing_heartbeat = eval_as_int_otherwise_none(getattr(settings, "STOMP_OUTGOING_HEARTBIT", "6000"))
+    incoming_heartbeat = eval_as_int_otherwise_none(getattr(settings, "STOMP_INCOMING_HEARTBIT", "6000"))
     subscription_id = getattr(settings, "STOMP_SUBSCRIPTION_ID", None)
 
     required_params = {

--- a/django_stomp/exceptions.py
+++ b/django_stomp/exceptions.py
@@ -1,2 +1,6 @@
 class CorrelationIdNotProvidedException(BaseException):
     pass
+
+
+class DjangoStompImproperlyConfigured(Exception):
+    pass

--- a/django_stomp/execution.py
+++ b/django_stomp/execution.py
@@ -24,7 +24,7 @@ wait_to_connect = int(getattr(settings, "STOMP_WAIT_TO_CONNECT", 10))
 durable_topic_subscription = eval_str_as_boolean(getattr(settings, "STOMP_DURABLE_TOPIC_SUBSCRIPTION", False))
 listener_client_id = getattr(settings, "STOMP_LISTENER_CLIENT_ID", None)
 is_correlation_id_required = eval_str_as_boolean(getattr(settings, "STOMP_CORRELATION_ID_REQUIRED", True))
-should_process_msg_on_background = eval_str_as_boolean(getattr(settings, "STOMP_PROCESS_MSG_ON_BACKGROUND", False))
+should_process_msg_on_background = eval_str_as_boolean(getattr(settings, "STOMP_PROCESS_MSG_ON_BACKGROUND", True))
 publisher_name = "django-stomp-another-target"
 
 

--- a/django_stomp/execution.py
+++ b/django_stomp/execution.py
@@ -24,6 +24,7 @@ wait_to_connect = int(getattr(settings, "STOMP_WAIT_TO_CONNECT", 10))
 durable_topic_subscription = eval_str_as_boolean(getattr(settings, "STOMP_DURABLE_TOPIC_SUBSCRIPTION", False))
 listener_client_id = getattr(settings, "STOMP_LISTENER_CLIENT_ID", None)
 is_correlation_id_required = eval_str_as_boolean(getattr(settings, "STOMP_CORRELATION_ID_REQUIRED", True))
+should_process_msg_on_background = eval_str_as_boolean(getattr(settings, "STOMP_PROCESS_MSG_ON_BACKGROUND", False))
 publisher_name = "django-stomp-another-target"
 
 
@@ -42,7 +43,13 @@ def start_processing(
         routing_key = get_subscription_destination(destination_name)
         _create_queue(destination_name, durable_topic_subscription=True, routing_key=routing_key)
     client_id = get_listener_client_id(durable_topic_subscription, listener_client_id)
-    listener = build_listener(destination_name, durable_topic_subscription, client_id=client_id)
+
+    listener = build_listener(
+        destination_name,
+        durable_topic_subscription,
+        client_id=client_id,
+        should_process_msg_on_background=should_process_msg_on_background,
+    )
 
     def main_logic() -> Optional[Listener]:
         try:

--- a/django_stomp/helpers.py
+++ b/django_stomp/helpers.py
@@ -105,3 +105,13 @@ def retry(function: Callable, attempt=10, *args, **kwargs):
 
 def eval_as_int_if_provided_value_is_not_none_otherwise_none(value):
     return int(value) if value is not None else None
+
+
+def is_heartbeat_enabled(outgoing_heartbeat: int, incoming_heartbeat: int):
+    """
+    Determine if STOMP heartbeat is enabled or not. Per the specification, it'll only be enabled
+    if a both estabilished times is greater than zero.
+
+    More on: https://stomp.github.io/stomp-specification-1.1.html#Heart-beating
+    """
+    return outgoing_heartbeat > 0 and incoming_heartbeat > 0

--- a/django_stomp/helpers.py
+++ b/django_stomp/helpers.py
@@ -2,11 +2,10 @@ import functools
 import logging
 import time
 import uuid
-from typing import Dict
 from typing import Callable
+from typing import Dict
 
 import tenacity
-
 
 logger = logging.getLogger("django_stomp")
 
@@ -102,3 +101,7 @@ def retry(function: Callable, attempt=10, *args, **kwargs):
         reraise=True,
     )
     return retry_configuration(function, *args, **kwargs)
+
+
+def eval_as_int_if_provided_value_is_not_none_otherwise_none(value):
+    return int(value) if value is not None else None

--- a/django_stomp/services/consumer.py
+++ b/django_stomp/services/consumer.py
@@ -11,14 +11,12 @@ from typing import Dict
 from typing import Optional
 
 import stomp
-from django.conf import settings
 from django_stomp.helpers import create_dlq_destination_from_another_destination
 from django_stomp.helpers import only_destination_name
+from django_stomp.settings import STOMP_PROCESS_MSG_WORKERS
 from stomp import connect
 
 logger = logging.getLogger("django_stomp")
-
-STOMP_PROCESS_MSG_WORKERS = getattr(settings, "STOMP_PROCESS_MSG_WORKERS", None)
 
 
 class Acknowledgements(Enum):

--- a/django_stomp/settings.py
+++ b/django_stomp/settings.py
@@ -1,0 +1,21 @@
+from typing import Any
+from typing import Callable
+from typing import Optional
+
+from django.conf import settings as django_settings
+from django_stomp.exceptions import DjangoStompImproperlyConfigured
+from django_stomp.helpers import eval_as_int_if_provided_value_is_not_none_otherwise_none
+
+
+def eval_settings_otherwise_raise_exception(
+    settings_name: str, evaluation_callback: Callable, default_value: Optional[Any] = None
+):
+    try:
+        return evaluation_callback(getattr(django_settings, settings_name, default_value))
+    except Exception:
+        raise DjangoStompImproperlyConfigured(f"The defined {settings_name} is not valid!")
+
+
+STOMP_PROCESS_MSG_WORKERS = eval_settings_otherwise_raise_exception(
+    "STOMP_PROCESS_MSG_WORKERS", eval_as_int_if_provided_value_is_not_none_otherwise_none
+)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="django-stomp",
-    version="2.1.1",
+    version="2.2.1",
     description="A simple implementation of STOMP with Django",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="django-stomp",
-    version="2.2.1",
+    version="2.2.0",
     description="A simple implementation of STOMP with Django",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="django-stomp",
-    version="2.2.0",
+    version="3.0.0",
     description="A simple implementation of STOMP with Django",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/integration/test_execution.py
+++ b/tests/integration/test_execution.py
@@ -631,10 +631,12 @@ def test_should_use_heartbeat_and_dont_lose_connection_when_using_background_pro
     )
     sending_heartbeat_message_regex = re.compile("Sending a heartbeat message at [0-9.]+")
     sending_ack_frame_regex = re.compile(f"Sending frame: .+ACK.+subscription:{message_consumer._subscription_id}.+")
+    heartbeat_timeout_regex = re.compile("Heartbeat timeout: diff_receive=[0-9.]+, time=[0-9.]+, lastrec=[0-9.]+")
 
     assert any(received_heartbeat_frame_regex.match(m) for m in caplog.messages)
     assert any(sending_heartbeat_message_regex.match(m) for m in caplog.messages)
     assert any(sending_ack_frame_regex.match(m) for m in caplog.messages)
+    assert any(heartbeat_timeout_regex.match(m) for m in caplog.messages)
 
 
 def _test_callback_function_standard(payload: Payload):

--- a/tests/integration/test_execution.py
+++ b/tests/integration/test_execution.py
@@ -377,6 +377,7 @@ def test_should_use_heartbeat_and_then_lost_connection_due_message_takes_longer_
 
     settings.STOMP_OUTGOING_HEARTBIT = 1000
     settings.STOMP_INCOMING_HEARTBIT = 1000
+    mocker.patch("django_stomp.execution.should_process_msg_on_background", False)
 
     message_consumer = start_processing(
         some_destination,
@@ -617,7 +618,6 @@ def test_should_use_heartbeat_and_dont_lose_connection_when_using_background_pro
 
     settings.STOMP_OUTGOING_HEARTBIT = 1000
     settings.STOMP_INCOMING_HEARTBIT = 1000
-    mocker.patch("django_stomp.execution.should_process_msg_on_background", True)
 
     message_consumer = start_processing(
         some_destination, myself_with_test_callback_sleep_three_seconds, is_testing=True, return_listener=True

--- a/tests/integration/test_execution.py
+++ b/tests/integration/test_execution.py
@@ -636,7 +636,7 @@ def test_should_use_heartbeat_and_dont_lose_connection_when_using_background_pro
     assert any(received_heartbeat_frame_regex.match(m) for m in caplog.messages)
     assert any(sending_heartbeat_message_regex.match(m) for m in caplog.messages)
     assert any(sending_ack_frame_regex.match(m) for m in caplog.messages)
-    assert any(heartbeat_timeout_regex.match(m) for m in caplog.messages)
+    assert not any(heartbeat_timeout_regex.match(m) for m in caplog.messages)
 
 
 def _test_callback_function_standard(payload: Payload):

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -42,3 +42,11 @@ def get_currently_active_threads_name():
     Retrieves the threads name that are currently active
     """
     return [thread.name for thread in threading.enumerate()]
+
+
+def get_active_threads_name_with_prefix(prefix: str):
+    """
+    Retrieves the threads name that starts with `prefix` and are active.
+    """
+    prefix_regex = re.compile(f"^{prefix}")
+    return [thread.name for thread in threading.enumerate() if prefix_regex.match(thread.name)]

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1,4 +1,5 @@
 import re
+import threading
 from time import sleep
 
 
@@ -34,3 +35,10 @@ def wait_for_message_in_log(caplog, message_to_wait, message_count_to_wait=None,
             break
         max_seconds_to_wait -= 1
         sleep(1)
+
+
+def get_currently_active_threads_name():
+    """
+    Retrieves the threads name that are currently active
+    """
+    return [thread.name for thread in threading.enumerate()]

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -37,13 +37,6 @@ def wait_for_message_in_log(caplog, message_to_wait, message_count_to_wait=None,
         sleep(1)
 
 
-def get_currently_active_threads_name():
-    """
-    Retrieves the threads name that are currently active
-    """
-    return [thread.name for thread in threading.enumerate()]
-
-
 def get_active_threads_name_with_prefix(prefix: str):
     """
     Retrieves the threads name that starts with `prefix` and are active.

--- a/tests/unit/services/test_consumer.py
+++ b/tests/unit/services/test_consumer.py
@@ -1,0 +1,20 @@
+import json
+from uuid import uuid4
+
+from django_stomp.services.consumer import build_listener
+from tests.support.helpers import get_currently_active_threads_name
+
+
+def test_should_clean_up_thread_pool_when_listener_is_deleted():
+    listener = build_listener(f"some-destination-{uuid4()}", should_process_msg_on_background=True)
+
+    listener.on_message(headers={"message-id": "123"}, body=json.dumps({"someKey": 1}))
+
+    threads_active_before_delete = get_currently_active_threads_name()
+
+    del listener
+
+    remaining_threads = get_currently_active_threads_name()
+
+    assert len(threads_active_before_delete) != len(remaining_threads)
+    assert sorted(threads_active_before_delete) != sorted(remaining_threads)

--- a/tests/unit/services/test_consumer.py
+++ b/tests/unit/services/test_consumer.py
@@ -2,19 +2,53 @@ import json
 from uuid import uuid4
 
 from django_stomp.services.consumer import build_listener
-from tests.support.helpers import get_currently_active_threads_name
+from tests.support.helpers import get_active_threads_name_with_prefix
 
 
-def test_should_clean_up_thread_pool_when_listener_is_deleted():
+def test_should_create_at_most_the_defined_number_of_workers(mocker):
+    mocker.patch("django_stomp.services.consumer.STOMP_PROCESS_MSG_WORKERS", 3)
+
+    listener = build_listener(f"some-destination-{uuid4()}", should_process_msg_on_background=True)
+
+    listener.on_message(headers={"message-id": "123"}, body=json.dumps({"someKey": 1}))
+    listener.on_message(headers={"message-id": "123"}, body=json.dumps({"someKey": 1}))
+    listener.on_message(headers={"message-id": "123"}, body=json.dumps({"someKey": 1}))
+    listener.on_message(headers={"message-id": "123"}, body=json.dumps({"someKey": 1}))
+
+    workers_threads = get_active_threads_name_with_prefix(listener._subscription_id)
+    assert len(workers_threads) == 3  # 3 workers
+    listener.shutdown_worker_pool()
+
+
+def test_should_clean_up_worker_pool():
     listener = build_listener(f"some-destination-{uuid4()}", should_process_msg_on_background=True)
 
     listener.on_message(headers={"message-id": "123"}, body=json.dumps({"someKey": 1}))
 
-    threads_active_before_delete = get_currently_active_threads_name()
+    workers_threads_before_pool_shutdown = get_active_threads_name_with_prefix(listener._subscription_id)
+    assert len(workers_threads_before_pool_shutdown) == 1  # only one worker
 
-    del listener
+    listener.shutdown_worker_pool()
 
-    remaining_threads = get_currently_active_threads_name()
+    workers_threads_after_pool_shutdown = get_active_threads_name_with_prefix(listener._subscription_id)
+    assert len(workers_threads_after_pool_shutdown) == 0  # no active worker thread
 
-    assert len(threads_active_before_delete) != len(remaining_threads)
-    assert sorted(threads_active_before_delete) != sorted(remaining_threads)
+
+def test_should_still_process_message_if_worker_pool_was_explicitly_shutdown():
+    listener = build_listener(f"some-destination-{uuid4()}", should_process_msg_on_background=True)
+
+    listener.on_message(headers={"message-id": "123"}, body=json.dumps({"someKey": 1}))
+
+    workers_threads_before_pool_shutdown = get_active_threads_name_with_prefix(listener._subscription_id)
+    assert len(workers_threads_before_pool_shutdown) == 1  # only one worker
+    listener.shutdown_worker_pool()
+
+    workers_threads_after_pool_shutdown = get_active_threads_name_with_prefix(listener._subscription_id)
+    assert len(workers_threads_after_pool_shutdown) == 0  # no active worker thread
+
+    listener.on_message(headers={"message-id": "123"}, body=json.dumps({"someKey": 1}))
+
+    workers_threads_before_pool_shutdown = get_active_threads_name_with_prefix(listener._subscription_id)
+    assert len(workers_threads_before_pool_shutdown) == 1  # only one worker
+
+    listener.shutdown_worker_pool()

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,0 +1,48 @@
+import pytest
+from django_stomp.exceptions import DjangoStompImproperlyConfigured
+from django_stomp.settings import eval_as_int_if_provided_value_is_not_none_otherwise_none
+from django_stomp.settings import eval_settings_otherwise_raise_exception
+
+
+def test_should_raise_improperly_configured_when_settings_is_not_correct_configured(mocker):
+    mocked_settings = mocker.patch("django_stomp.settings.django_settings")
+    mocked_settings.STOMP_PROCESS_MSG_WORKERS = "abc"
+
+    with pytest.raises(DjangoStompImproperlyConfigured, match="STOMP_PROCESS_MSG_WORKERS is not valid!"):
+        eval_settings_otherwise_raise_exception(
+            "STOMP_PROCESS_MSG_WORKERS", eval_as_int_if_provided_value_is_not_none_otherwise_none
+        )
+
+    mocked_settings.STOMP_PROCESS_MSG_WORKERS = {}
+    with pytest.raises(DjangoStompImproperlyConfigured, match="STOMP_PROCESS_MSG_WORKERS is not valid!"):
+        eval_settings_otherwise_raise_exception(
+            "STOMP_PROCESS_MSG_WORKERS", eval_as_int_if_provided_value_is_not_none_otherwise_none
+        )
+
+    mocked_settings.STOMP_PROCESS_MSG_WORKERS = []
+    with pytest.raises(DjangoStompImproperlyConfigured, match="STOMP_PROCESS_MSG_WORKERS is not valid!"):
+        eval_settings_otherwise_raise_exception(
+            "STOMP_PROCESS_MSG_WORKERS", eval_as_int_if_provided_value_is_not_none_otherwise_none
+        )
+
+
+def test_should_evaluate_settings_when_it_is_configured_as_expected(mocker):
+    mocked_settings = mocker.patch("django_stomp.settings.django_settings")
+    mocked_settings.STOMP_PROCESS_MSG_WORKERS = None
+
+    evaluated_settings = eval_settings_otherwise_raise_exception(
+        "STOMP_PROCESS_MSG_WORKERS", eval_as_int_if_provided_value_is_not_none_otherwise_none
+    )
+    assert evaluated_settings is None
+
+    mocked_settings.STOMP_PROCESS_MSG_WORKERS = 123
+    evaluated_settings = eval_settings_otherwise_raise_exception(
+        "STOMP_PROCESS_MSG_WORKERS", eval_as_int_if_provided_value_is_not_none_otherwise_none
+    )
+    assert evaluated_settings == 123
+
+    mocked_settings.STOMP_PROCESS_MSG_WORKERS = "3"
+    evaluated_settings = eval_settings_otherwise_raise_exception(
+        "STOMP_PROCESS_MSG_WORKERS", eval_as_int_if_provided_value_is_not_none_otherwise_none
+    )
+    assert evaluated_settings == 3


### PR DESCRIPTION
In order to process the message on background, this PR try to resolve #19 enabling a new parameter (`STOMP_PROCESS_MSG_ON_BACKGROUND`) that should be added to the project settings that uses this library. This new parameter enables the callback execution that is passed when a new message frame arrives to occurs on background in a new thread. Those threads are managed by a `ThreadPoolExecutor`.

Also, it was added an optional parameter (`STOMP_PROCESS_MSG_WORKERS`) to control the maximum number of worker threads to be spawned.