### PR TITLE
Bugfix/virtual topic durable subscriber

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,3 +176,6 @@ asssumed to be `/queue/DLQ.some-queue`.
 and process any `heart-beat` frame sent by the server, causing the client to terminate the connection due to a false 
 positive heartbeat timeout. You can workaround it with the `STOMP_PROCESS_MSG_ON_BACKGROUND` parameter that uses a
 thread pool to process the message.
+* For the RabbitMQ users: the **django-stomp consumer** always try to connect to a 
+[durable queue](https://www.rabbitmq.com/queues.html#durability), so if your queue is not durable, the RabbitMQ broker 
+will not allow the subscription.

--- a/django_stomp/execution.py
+++ b/django_stomp/execution.py
@@ -45,7 +45,7 @@ def start_processing(
         _create_dlq_queue(destination_name)
         if is_destination_from_virtual_topic(destination_name):
             routing_key = get_subscription_destination(destination_name)
-            _create_queue(destination_name, durable_topic_subscription=True, routing_key=routing_key)
+            _create_queue(destination_name, routing_key=routing_key)
             logger.info("Created/Refreshed queue to consume from topic in case of RabbitMQ...")
 
     client_id = get_listener_client_id(durable_topic_subscription, listener_client_id)

--- a/django_stomp/services/consumer.py
+++ b/django_stomp/services/consumer.py
@@ -182,6 +182,7 @@ def build_listener(
         # RabbitMQ
         "x-queue-name": only_destination_name(destination_name),
         "auto-delete": "false",
+        "durable": "true",
     }
     header_setup = {
         # ActiveMQ
@@ -199,8 +200,6 @@ def build_listener(
             # ActiveMQ
             "activemq.subscriptionName": header_setup["client-id"],
             "activemq.subcriptionName": header_setup["client-id"],
-            # RabbitMQ
-            "durable": "true",
         }
         header_setup.update(durable_subs_header)
     connection_configuration = {

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="django-stomp",
-    version="4.0.0",
+    version="4.0.1",
     description="A simple implementation of STOMP with Django",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/integration/test_execution.py
+++ b/tests/integration/test_execution.py
@@ -23,6 +23,7 @@ from tests.support.activemq.message_details import retrieve_message_published
 from tests.support.activemq.queue_details import current_queue_configuration
 from tests.support.activemq.subscribers_details import offline_durable_subscribers
 from tests.support.activemq.topic_details import current_topic_configuration
+from tests.support.helpers import is_testing_against_rabbitmq
 from tests.support.helpers import wait_for_message_in_log
 
 myself_with_test_callback_standard = "tests.integration.test_execution._test_callback_function_standard"
@@ -168,6 +169,7 @@ def test_should_create_durable_subscriber_and_receive_standby_messages(mocker: M
         assert destination_status.messages_dequeued == 3
 
         all_offline_subscribers = list(offline_durable_subscribers("localhost"))
+        assert len(all_offline_subscribers) > 0
         for index, subscriber_setup in enumerate(all_offline_subscribers):
             if subscriber_setup.subscriber_id == f"{temp_uuid_listener}-listener":
                 assert subscriber_setup.dispatched_counter == 3
@@ -637,6 +639,21 @@ def test_should_use_heartbeat_and_dont_lose_connection_when_using_background_pro
     assert any(sending_heartbeat_message_regex.match(m) for m in caplog.messages)
     assert any(sending_ack_frame_regex.match(m) for m in caplog.messages)
     assert not any(heartbeat_timeout_regex.match(m) for m in caplog.messages)
+
+
+@pytest.mark.skipif(is_testing_against_rabbitmq(), reason="RabbitMQ doesn't holds the concept of a durable subscriber")
+def test_shouldnt_create_a_durable_subscriber_when_dealing_with_virtual_topics():
+    all_offline_subscribers_before_the_virtual_topic_connection = list(offline_durable_subscribers("localhost"))
+
+    some_virtual_topic = f"VirtualTopic.{uuid.uuid4()}"
+    virtual_topic_consumer_queue = f"Consumer.{uuid.uuid4()}.{some_virtual_topic}"
+    start_processing(virtual_topic_consumer_queue, myself_with_test_callback_one, is_testing=True)
+
+    all_offline_subscribers_after_the_virtual_topic_connection = list(offline_durable_subscribers("localhost"))
+
+    assert sorted(all_offline_subscribers_before_the_virtual_topic_connection) == sorted(
+        all_offline_subscribers_after_the_virtual_topic_connection
+    )
 
 
 def _test_callback_function_standard(payload: Payload):

--- a/tests/integration/test_execution.py
+++ b/tests/integration/test_execution.py
@@ -666,9 +666,8 @@ def test_should_connect_with_a_queue_created_without_the_durable_header(caplog):
     listener.close()
 
     send_frames_with_durable_true_regex = re.compile(r"^Sending frame:.*durable:true.*")
-    send_frames_with_durable_true_logs = [m for m in caplog.messages if send_frames_with_durable_true_regex.match(m)]
 
-    assert not send_frames_with_durable_true_logs
+    assert all(not send_frames_with_durable_true_regex.match(m) for m in caplog.messages)
 
     publisher = build_publisher()
     some_correlation_id = uuid.uuid4()
@@ -685,7 +684,9 @@ def test_should_connect_with_a_queue_created_without_the_durable_header(caplog):
     message_consumer.close()
 
     consumer_log_message_regex = re.compile(f"I'll process the message: {some_body}!")
-    assert any([consumer_log_message_regex.match(m) for m in caplog.messages])
+
+    assert any(send_frames_with_durable_true_regex.match(m) for m in caplog.messages)
+    assert any(consumer_log_message_regex.match(m) for m in caplog.messages)
 
 
 def _test_callback_function_standard(payload: Payload):

--- a/tests/support/activemq/subscribers_details.py
+++ b/tests/support/activemq/subscribers_details.py
@@ -18,7 +18,6 @@ def offline_durable_subscribers(host) -> Generator[SubscriberSetup, None, None]:
         .getall()
     )
 
-    assert len(all_offline_subscribers) > 0
     for index, column_details in enumerate(all_offline_subscribers):
         column_details_as_selector = Selector(text=column_details)
         client_id_request_path = column_details_as_selector.css("td a::attr(href)").get()

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -2,6 +2,8 @@ import re
 import threading
 from time import sleep
 
+from tests.support import rabbitmq
+
 
 def iterable_len(iterable):
     """
@@ -43,3 +45,14 @@ def get_active_threads_name_with_prefix(prefix: str):
     """
     prefix_regex = re.compile(f"^{prefix}")
     return [thread.name for thread in threading.enumerate() if prefix_regex.match(thread.name)]
+
+
+def is_testing_against_rabbitmq() -> bool:
+    """
+    Verify if the test suite is running against RabbitMQ.
+    """
+    try:
+        rabbitmq.get_broker_version()
+        return True
+    except Exception:
+        return False

--- a/tests/support/rabbitmq/__init__.py
+++ b/tests/support/rabbitmq/__init__.py
@@ -16,6 +16,7 @@ _bindings_from_queue_request_path = _queues_details_request_path + "/%2F/{queue_
 _get_message_from_queue_request_path = _queues_details_request_path + "/%2F/{queue_name}/get"
 _channels_details_request_path = "/api/channels"
 _channel_details_from_channel_request_path = _channels_details_request_path + "/{channel_name}"
+_overview_request_path = "/api/overview"
 
 
 def current_queue_configuration(queue_name, host="localhost", port=15672) -> Optional[CurrentDestinationStatus]:
@@ -110,6 +111,11 @@ def retrieve_message_published(destination_name, host="localhost", port=15672) -
     headers = properties.pop("headers")
 
     return MessageStatus(None, details, persistent, correlation_id, {**headers, **properties})
+
+
+def get_broker_version(host="localhost", port=15672) -> str:
+    broker_overview = _do_request(host, port, _overview_request_path)
+    return broker_overview["rabbitmq_version"]
 
 
 def _do_request(host, port, request_path, do_post=False, body=None):


### PR DESCRIPTION
Due to a workaround that introduces the concept of **Virtual Topics** in RabbitMQ, we're creating **durable topic subscribers** on ActiveMQ. This workaround involved the necessity to pass the header `durable=true` to create/use a durable queue, since if we don't pass the `durable` header to RabbitMQ, it assumes that it should use the durable property of its exchange which is not always `true` (for queues, it's the default exchange which is `durable=true`).

So, what is changed here:

* First of all, when creating/refreshing the queue for the virtual topic consumer, the `start_processing` doesn't create a **durable topic subscriber** anymore;
* Since the `durable=true` is desirable (it informs the **RabbitMQ** broker to maintain the queue/exchange if the broker restart), we set it by default, so that every **django-stomp consumer** always send it. So, if the queue does not exist, the **RabbitMQ** create it as durable and if it already exists, it simply starts to consume from it.