### PR TITLE
Added new command for acking all messages on a destination

### DIFF
--- a/django_stomp/exceptions.py
+++ b/django_stomp/exceptions.py
@@ -4,3 +4,11 @@ class CorrelationIdNotProvidedException(BaseException):
 
 class DjangoStompImproperlyConfigured(Exception):
     pass
+
+
+class DjangoStompIncorrectUse(BaseException):
+    """
+    Raised when Django stomp has been invoked in a wrong manner such as
+    less arguments than it needs, etc.
+    """
+    pass

--- a/django_stomp/execution.py
+++ b/django_stomp/execution.py
@@ -140,7 +140,7 @@ def send_message_from_one_destination_to_another(
     )
 
 
-def clean_messages_on_queue_by_acking(
+def clean_messages_on_destination_by_acking(
     source_destination: str, is_testing: bool = False, testing_disconnect: bool = True, return_listener: bool = False,
 ) -> Listener:
     """

--- a/django_stomp/execution.py
+++ b/django_stomp/execution.py
@@ -139,11 +139,9 @@ def send_message_from_one_destination_to_another(
         broker_port_to_consume_messages=custom_stomp_server_port,
     )
 
+
 def clean_messages_on_queue_by_acking(
-    source_destination: str,
-    is_testing: bool = False,
-    testing_disconnect: bool = True,
-    return_listener: bool = False,
+    source_destination: str, is_testing: bool = False, testing_disconnect: bool = True, return_listener: bool = False,
 ) -> Listener:
     """
     Cleans a queue by acking all messages on it (no queue purging or deleting).
@@ -170,7 +168,6 @@ def _callback_for_cleaning_queues(payload: Payload):
 
     payload.ack()
     logger.info("Message has been removed!")
-
 
 
 def _callback_send_to_another_destination(payload: Payload, target_destination):

--- a/django_stomp/management/commands/ack_all_messages.py
+++ b/django_stomp/management/commands/ack_all_messages.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 from django_stomp.exceptions import DjangoStompIncorrectUse
-from django_stomp.execution import clean_messages_on_queue_by_acking
+from django_stomp.execution import clean_messages_on_destination_by_acking
 
 
 class Command(BaseCommand):
@@ -17,4 +17,4 @@ class Command(BaseCommand):
             raise DjangoStompIncorrectUse("No destination_to_clean was supplied! Nothing to clean!")
 
         self.stdout.write(f"Preparing to clean the queue: {source_destination}")
-        clean_messages_on_queue_by_acking(source_destination)
+        clean_messages_on_destination_by_acking(source_destination)

--- a/django_stomp/management/commands/clean_queue.py
+++ b/django_stomp/management/commands/clean_queue.py
@@ -1,0 +1,21 @@
+from django.core.management.base import BaseCommand
+
+from django_stomp.exceptions import DjangoStompIncorrectUse
+from django_stomp.execution import start_processing, clean_messages_on_queue_by_acking
+
+
+class Command(BaseCommand):
+    help = "Cleans a destination by acking all messages on it!"
+
+    def add_arguments(self, parser):
+        parser.add_argument("destination_to_clean", type=str, help="Destination to be cleaned from all messages")
+
+    def handle(self, *args, **options):
+        self.stdout.write(f"Provided parameters: {options}")
+        source_destination = options.get("destination_to_clean")
+
+        if not source_destination:
+            raise DjangoStompIncorrectUse("No destination_to_clean was supplied! Nothing to clean!")
+
+        self.stdout.write(f"Preparing to clean the queue: {source_destination}")
+        clean_messages_on_queue_by_acking(source_destination)

--- a/django_stomp/management/commands/clean_queue.py
+++ b/django_stomp/management/commands/clean_queue.py
@@ -1,7 +1,6 @@
 from django.core.management.base import BaseCommand
-
 from django_stomp.exceptions import DjangoStompIncorrectUse
-from django_stomp.execution import start_processing, clean_messages_on_queue_by_acking
+from django_stomp.execution import clean_messages_on_queue_by_acking
 
 
 class Command(BaseCommand):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="django-stomp",
-    version="4.0.1",
+    version="4.1.0",
     description="A simple implementation of STOMP with Django",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/integration/test_execution.py
+++ b/tests/integration/test_execution.py
@@ -11,7 +11,8 @@ from django.core.management import call_command
 from django.core.serializers.json import DjangoJSONEncoder
 from django_stomp.builder import build_listener
 from django_stomp.builder import build_publisher
-from django_stomp.execution import send_message_from_one_destination_to_another, clean_messages_on_queue_by_acking
+from django_stomp.execution import clean_messages_on_destination_by_acking
+from django_stomp.execution import send_message_from_one_destination_to_another
 from django_stomp.execution import start_processing
 from django_stomp.helpers import clean_dict_with_falsy_or_strange_values
 from django_stomp.helpers import create_dlq_destination_from_another_destination
@@ -772,7 +773,7 @@ def test_should_clean_all_messages_on_a_destination(caplog):
             publisher.send(some_body, some_source_destination, some_headers, attempt=1)
 
     # # command invocation
-    consumer = clean_messages_on_queue_by_acking(some_source_destination, is_testing=True, return_listener=True)
+    consumer = clean_messages_on_destination_by_acking(some_source_destination, is_testing=True, return_listener=True)
     wait_for_message_in_log(caplog, r"Message has been removed!", message_count_to_wait=trash_msgs_count)
     consumer.close()
 

--- a/tests/integration/test_execution.py
+++ b/tests/integration/test_execution.py
@@ -7,10 +7,11 @@ from time import sleep
 
 import pytest
 import trio
+from django.core.management import call_command
 from django.core.serializers.json import DjangoJSONEncoder
 from django_stomp.builder import build_listener
 from django_stomp.builder import build_publisher
-from django_stomp.execution import send_message_from_one_destination_to_another
+from django_stomp.execution import send_message_from_one_destination_to_another, clean_messages_on_queue_by_acking
 from django_stomp.execution import start_processing
 from django_stomp.helpers import clean_dict_with_falsy_or_strange_values
 from django_stomp.helpers import create_dlq_destination_from_another_destination
@@ -754,3 +755,38 @@ def _test_callback_function_with_sleep_three_seconds(payload: Payload):
     payload.ack()
     logger = logging.getLogger(__name__)
     logger.info("%s sucessfully processed!", payload.body)
+
+
+def test_should_clean_all_messages_on_a_destination(caplog):
+    caplog.set_level(logging.DEBUG)
+
+    some_source_destination = f"/queue/flood-this-queue-with-trash"
+    trash_msgs_count = 10
+
+    # publishes trash to a destination
+    with build_publisher().auto_open_close_connection() as publisher:
+        some_body = {"some": "trash"}
+        some_headers = {"some": "header"}
+
+        for i in range(0, trash_msgs_count):
+            publisher.send(some_body, some_source_destination, some_headers, attempt=1)
+
+    # # command invocation
+    consumer = clean_messages_on_queue_by_acking(some_source_destination, is_testing=True, return_listener=True)
+    wait_for_message_in_log(caplog, r"Message has been removed!", message_count_to_wait=trash_msgs_count)
+    consumer.close()
+
+    # removing /queue/
+    *_, source_queue_name = some_source_destination.split("/")
+
+    try:
+        # if activemq broker is running
+        source_queue_status = current_queue_configuration(source_queue_name)
+    except Exception:
+        # if rabbitmq broker is running
+        source_queue_status = rabbitmq.current_queue_configuration(source_queue_name)
+
+    assert source_queue_status.number_of_pending_messages == 0
+    assert source_queue_status.number_of_consumers == 0
+    assert source_queue_status.messages_enqueued == 10
+    assert source_queue_status.messages_dequeued == 10  # cleaned queue!

--- a/tests/integration/test_execution.py
+++ b/tests/integration/test_execution.py
@@ -788,5 +788,5 @@ def test_should_clean_all_messages_on_a_destination(caplog):
 
     assert source_queue_status.number_of_pending_messages == 0
     assert source_queue_status.number_of_consumers == 0
-    assert source_queue_status.messages_enqueued == 10
-    assert source_queue_status.messages_dequeued == 10  # cleaned queue!
+    assert source_queue_status.messages_enqueued == trash_msgs_count  # enqueued the queue with trash!
+    assert source_queue_status.messages_dequeued == trash_msgs_count  # cleaned all the trash on the queue!


### PR DESCRIPTION
# What is being delivered?

A new command for acking all messages on a specific destination, to be used as follows:

```python
python manage.py ack_all_messages destination_name
```

This command does not purge or deletes a destination, it consumes every message and acks every each one of them.