### PR TITLE
Proper unsafe headers cleaning

### DIFF
--- a/django_stomp/services/producer.py
+++ b/django_stomp/services/producer.py
@@ -22,11 +22,11 @@ logger = logging.getLogger("django_stomp")
 
 class Publisher:
     """
-    Class used for publishing messages to ActiveMQ or RabbitMQ brokers using STOMP. Some headers must be removed
-    if supplied via the send() method as they cause unexpected behavior/errors. 
+    Class used to publish messages to ActiveMQ/RabbitMQ brokers using STOMP protocol. Some headers are removed
+    if they are in the send() method as they cause unexpected behavior/errors. 
     
-    Such headers are contained in the UNSAFE_OR_RESERVED_BROKER_HEADERS_FOR_REMOVAL class variable and used
-    for sanitizing user-supplied headers. 
+    Such headers are defined in the UNSAFE_OR_RESERVED_BROKER_HEADERS_FOR_REMOVAL class variable which is used
+    for sanitizing the user-supplied headers. 
     """
 
     UNSAFE_OR_RESERVED_BROKER_HEADERS_FOR_REMOVAL = [
@@ -101,8 +101,8 @@ class Publisher:
 
     def _get_correlation_id(self, headers: Optional[Dict]) -> str:
         """
-        Gets the correlation id for the message. If 'correlation-id' is supplied via headers, it's returned. 
-        Otherwise, returns current_request_id() or generates a new one as a last resort.
+        Gets the correlation id for the message. If 'correlation-id' is in the headers, this value is used. 
+        Otherwise, the value of current_request_id() is returned or a new one is generated as a last resort.
         """
         if headers and "correlation-id" in headers:
             return headers["correlation-id"]
@@ -112,8 +112,7 @@ class Publisher:
 
     def _remove_unsafe_or_reserved_for_broker_use_headers(self, headers: Dict) -> Dict:
         """
-        Removes headers that are used internally by the brokers or that might
-        cause unexpected behaviors (unsafe).
+        Removes headers that are used internally by the brokers or that might cause unexpected behaviors (unsafe).
         """
         clean_headers = {
             key: headers[key] for key in headers if key not in self.UNSAFE_OR_RESERVED_BROKER_HEADERS_FOR_REMOVAL
@@ -138,7 +137,8 @@ class Publisher:
 
     def _send_to_broker(self, send_data: Dict, how_many_attempts: int) -> None:
         """
-        Sends the actual data to the broker using the STOMP protocol.
+        Sends the actual data to the broker using the STOMP protocol with some retry attempts if
+        a connection problem occurs.
         """
 
         def _internal_send_logic():

--- a/django_stomp/services/producer.py
+++ b/django_stomp/services/producer.py
@@ -1,4 +1,3 @@
-import copy
 import json
 import logging
 import ssl

--- a/django_stomp/services/producer.py
+++ b/django_stomp/services/producer.py
@@ -51,8 +51,8 @@ class Publisher:
         """
         Builds the final message headers/body and sends to the broker with the STOMP protocol.
         """
-        final_headers = self._build_final_headers(queue, headers, persistent)
-        send_data = self._build_send_data(queue, body, final_headers)
+        headers = self._build_final_headers(queue, headers, persistent)
+        send_data = self._build_send_data(queue, body, headers)
 
         self._send_to_broker(send_data, how_many_attempts=attempt)
 
@@ -92,14 +92,14 @@ class Publisher:
 
         return clean_headers
 
-    def _build_send_data(self, queue: str, body: Dict, clean_headers: Dict) -> Dict:
+    def _build_send_data(self, queue: str, body: Dict, headers: Dict) -> Dict:
         """
         Builds the final data shape required to send messages using the STOMP protocol.
         """
         send_data = {
             "destination": queue,
             "body": json.dumps(body, cls=DjangoJSONEncoder),
-            "headers": clean_headers,
+            "headers": headers,
             "content_type": self._default_content_type,
             "transaction": getattr(self, "_tmp_transaction_id", None),
         }

--- a/django_stomp/services/producer.py
+++ b/django_stomp/services/producer.py
@@ -27,11 +27,11 @@ class Publisher:
     if supplied via the send() method as they cause unexpected behavior/errors. 
     
     Such headers are contained in the UNSAFE_OR_RESERVED_BROKER_HEADERS_FOR_REMOVAL class variable and used
-    for sanitizing user headers. 
+    for sanitizing user-supplied headers. 
     """
 
     UNSAFE_OR_RESERVED_BROKER_HEADERS_FOR_REMOVAL = [
-        # RabbitMQ problematic headers
+        # RabbitMQ unsafe headers
         "message-id",
         "transaction",
         "redelivered",
@@ -91,14 +91,14 @@ class Publisher:
             "x-dead-letter-exchange": "",
         }
 
-        # safety: standard_headers must override headers values, order matters here
+        # safety: standard_headers must override headers values, so order MATTERS here!
         mixed_headers = {**headers, **standard_headers}
 
         if persistent:
             self._add_persistent_messaging_header(mixed_headers)
 
-        clean_headers = self._remove_unsafe_or_reserved_for_broker_use_headers(mixed_headers)
-        return clean_headers
+        final_headers = self._remove_unsafe_or_reserved_for_broker_use_headers(mixed_headers)
+        return final_headers
 
     def _get_correlation_id(self, headers: Optional[Dict]) -> str:
         """

--- a/django_stomp/services/producer.py
+++ b/django_stomp/services/producer.py
@@ -22,7 +22,7 @@ logger = logging.getLogger("django_stomp")
 
 class Publisher:
     """
-    Class used to publish messages to ActiveMQ/RabbitMQ brokers using STOMP protocol. Some headers are removed
+    Class used to publish messages to brokers using the STOMP protocol. Some headers are removed
     if they are in the send() method as they cause unexpected behavior/errors. 
     
     Such headers are defined in the UNSAFE_OR_RESERVED_BROKER_HEADERS_FOR_REMOVAL class variable which is used
@@ -73,7 +73,7 @@ class Publisher:
 
         self._send_to_broker(send_data, how_many_attempts=attempt)
 
-    def _build_final_headers(self, queue: str, headers: Dict, persistent: bool) -> Dict:
+    def _build_final_headers(self, queue: str, headers: Optional[Dict], persistent: bool) -> Dict:
         """
         Builds the message final headers. Removes unsafe or broker-reserved headers.
         Standard headers values override headers values to reduce possible errors.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="django-stomp",
-    version="4.1.1",
+    version="4.1.2",
     description="A simple implementation of STOMP with Django",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/integration/test_execution.py
+++ b/tests/integration/test_execution.py
@@ -750,7 +750,7 @@ def test_should_clean_all_messages_on_a_destination(caplog):
     consumer.close()
 
     # asserts that messages were acked
-    sleep(5)  # takes some time to ack all messages
+    sleep(15)  # takes some time to ack all messages, specially on the pipeline
     source_queue_status = get_destination_metrics_from_broker(source_queue_name)
 
     assert source_queue_status.number_of_pending_messages == 0

--- a/tests/integration/test_execution.py
+++ b/tests/integration/test_execution.py
@@ -741,8 +741,9 @@ def test_should_clean_all_messages_on_a_destination(caplog):
     some_body = {"some": "trash"}
     some_headers = {"some": "header"}
 
-    for i in range(0, trash_msgs_count):
-        publish_to_destination(some_source_destination, some_body, some_headers)
+    with build_publisher().auto_open_close_connection() as publisher:
+        for i in range(0, trash_msgs_count):
+            publisher.send(some_body, some_source_destination, some_headers, attempt=1)
 
     # # command invocation
     consumer = clean_messages_on_destination_by_acking(some_source_destination, is_testing=True, return_listener=True)
@@ -750,7 +751,7 @@ def test_should_clean_all_messages_on_a_destination(caplog):
     consumer.close()
 
     # asserts that messages were acked
-    sleep(15)  # takes some time to ack all messages, specially on the pipeline
+    sleep(5)  # takes some time to ack all messages
     source_queue_status = get_destination_metrics_from_broker(source_queue_name)
 
     assert source_queue_status.number_of_pending_messages == 0

--- a/tests/support/callbacks_for_tests.py
+++ b/tests/support/callbacks_for_tests.py
@@ -1,0 +1,76 @@
+"""
+Module with testing callbacks used for the tests.
+"""
+import logging
+import threading
+from time import sleep
+from typing import Callable
+from uuid import uuid4
+
+from django_stomp.builder import build_publisher
+from django_stomp.services.consumer import Payload
+
+callback_move_and_ack_path = "tests.support.callbacks_for_tests.callback_move_and_ack"
+callback_standard_path = "tests.support.callbacks_for_tests.callback_standard"
+callback_with_exception_path = "tests.support.callbacks_for_tests.callback_with_exception"
+callback_with_sleep_three_seconds_while_heartbeat_thread_is_alive_path = (
+    "tests.support.callbacks_for_tests.callback_with_sleep_three_seconds_while_heartbeat_thread_is_alive"
+)
+callback_with_logging_path = "tests.support.callbacks_for_tests.callback_with_logging"
+callback_with_sleep_three_seconds_path = "tests.support.callbacks_for_tests.callback_with_sleep_three_seconds"
+callback_with_another_log_message_path = "tests.support.callbacks_for_tests.callback_with_another_log_message"
+callback_with_nack_path = "tests.support.callbacks_for_tests.callback_with_nack"
+
+
+def callback_move_and_ack(payload: Payload, destination: str):
+    """
+    Callback for moving to another destination. Requires start_processing() to be called
+    with param_to_callback.
+    """
+    publisher = build_publisher()
+    publisher.send(payload.body, destination, attempt=1)
+    payload.ack()
+
+
+def callback_standard(payload: Payload):
+    """
+    Standard callback with simple ack.
+    """
+    # Should dequeue the message
+    payload.ack()
+
+
+def callback_with_nack(payload: Payload):
+    payload.nack()
+
+
+def callback_with_exception(payload: Payload):
+    raise Exception("Lambe Sal")
+
+
+def callback_with_sleep_three_seconds_while_heartbeat_thread_is_alive(payload: Payload):
+    heartbeat_threads = [thread for thread in threading.enumerate() if "StompHeartbeatThread" in thread.name]
+    while True:
+        sleep(3)
+        heartbeat_threads = filter(lambda thread: "StompHeartbeatThread" in thread.name, threading.enumerate())
+        if all(not thread.is_alive() for thread in heartbeat_threads):
+            break
+
+
+def callback_with_logging(payload: Payload):
+    logger = logging.getLogger(__name__)
+    logger.info("I'll process the message: %s!", payload.body)
+    payload.ack()
+
+
+def callback_with_another_log_message(payload: Payload):
+    logger = logging.getLogger(__name__)
+    logger.info("%s is the message that I'll process!", payload.body)
+    payload.ack()
+
+
+def callback_with_sleep_three_seconds(payload: Payload):
+    sleep(3)
+    payload.ack()
+    logger = logging.getLogger(__name__)
+    logger.info("%s sucessfully processed!", payload.body)

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1,8 +1,94 @@
+import json
 import re
 import threading
 from time import sleep
+from typing import Dict
+from typing import Optional
+from uuid import uuid4
 
+from django.core.serializers.json import DjangoJSONEncoder
+from django_stomp.builder import build_listener
+from django_stomp.builder import build_publisher
+from django_stomp.helpers import clean_dict_with_falsy_or_strange_values
+from django_stomp.helpers import create_dlq_destination_from_another_destination
+from django_stomp.helpers import retry
 from tests.support import rabbitmq
+from tests.support.activemq.queue_details import current_queue_configuration
+from tests.support.dtos import CurrentDestinationStatus
+
+
+def get_destination_metrics_from_broker(destination_name: str) -> CurrentDestinationStatus:
+    """
+    Retrieves metrics from the broker management console regardless of the broker engine
+    ActiveMQ or RabbitMQ.
+    """
+    try:
+        destination_metrics = current_queue_configuration(destination_name)
+    except Exception:
+        destination_metrics = rabbitmq.current_queue_configuration(destination_name)  # type: ignore
+
+    return destination_metrics
+
+
+def publish_without_correlation_id_header(destination: str, body: str, attempt=1, persistent=True):
+    """
+    Publishes a message without correlation-id on the headers.
+    """
+    publisher = build_publisher()
+
+    standard_header = {
+        "tshoot-destination": destination,
+        # RabbitMQ
+        # These two parameters must be set on consumer side as well, otherwise you'll get precondition_failed
+        "x-dead-letter-routing-key": create_dlq_destination_from_another_destination(destination),
+        "x-dead-letter-exchange": "",
+    }
+
+    if persistent:
+        standard_header.update({"persistent": "true"})
+
+    send_params = {
+        "destination": destination,
+        "body": json.dumps(body, cls=DjangoJSONEncoder),
+        "headers": standard_header,
+        "content_type": "application/json;charset=utf-8",
+        "transaction": getattr(publisher, "_tmp_transaction_id", None),
+    }
+    send_params = clean_dict_with_falsy_or_strange_values(send_params)
+
+    def _internal_send_logic():
+        publisher.start_if_not_open()
+        publisher.connection.send(**send_params)
+
+    retry(_internal_send_logic, attempt=attempt)
+
+
+def publish_to_destination(
+    destination: str, body: Dict, headers: Dict = None, persistent: bool = True, attempts: int = 1
+) -> None:
+    """
+    Publishes a message to a destination.
+    """
+    with build_publisher(f"random-publisher-{uuid4()}").auto_open_close_connection() as publisher:
+        publisher.send(body=body, queue=destination, headers=headers, persistent=persistent, attempt=attempts)
+
+
+def get_latest_message_from_destination_using_test_listener(destination: str) -> Dict:
+    """
+    Gets the latest message using the test listener utility. It does not ack the message
+    on the destination queue.
+
+    [!]: It makes a test hang forever if a message never arrives at the destination.
+    """
+    evaluation_consumer = build_listener(destination, is_testing=True)
+    test_listener = evaluation_consumer._test_listener
+    evaluation_consumer.start(wait_forever=False)
+
+    # may wait forever if the msg never arrives
+    test_listener.wait_for_message()
+    received_message = test_listener.get_latest_message()
+
+    return received_message
 
 
 def iterable_len(iterable):

--- a/tests/unit/services/test_producer.py
+++ b/tests/unit/services/test_producer.py
@@ -18,7 +18,13 @@ def test_should_build_final_headers_without_removing_unsafe_headers(mocker):
     publisher = build_publisher("test-publisher")
     persistent = True
     queue = "/queue/test"
-    headers = {"eventType": "sentPurchaseReceipt", "another": "header"}
+    headers = {
+        "eventType": "sentPurchaseReceipt",
+        "another": "header",
+        "x-dead-letter-exchange": "",
+        "tshoot-destination": "/queue/wrrrrong-again",
+        "x-dead-letter-routing-key": "DLQ.wrong-really-wrong...",  # queue name should define this
+    }
 
     expected_final_headers = {
         "another": "header",
@@ -43,20 +49,34 @@ def test_should_build_final_headers_with_removal_of_unsafe_headers(mocker):
 
     publisher = build_publisher("test-publisher")
     persistent = True
-    queue = "/queue/test"
-    headers = {"eventType": "sentPurchaseReceipt", "message-id": "remove-me-please"}  # must be removed, its internal
+    queue = "/queue/some-destination"
 
-    expected_final_headers = {
-        # "message-id": "remove-me-please",  # should have been removed!
-        "correlation-id": current_request_id,
-        "eventType": "sentPurchaseReceipt",
-        "persistent": "true",
-        "tshoot-destination": "/queue/test",
+    # no correlation-id supplied here
+    raw_headers = {
+        "subscription": "77625173-42b5-4c62-9c24-1fc4a4668dcc-listener",
+        "destination": "/queue/some-destination",
+        "message-id": "T_77625173-42b5-4c62-9c24-1fc4a4668dcc-listener@@session-jSfP4eyH59eKxHaZDv59Cg@@2",
+        "redelivered": "false",
+        "x-dead-letter-routing-key": "DLQ.wrong-really-wrong-destination",
         "x-dead-letter-exchange": "",
-        "x-dead-letter-routing-key": "DLQ.test",
+        "tshoot-destination": "/queue/wrong-really-wrong-destination",
+        "transaction": "11837f0b-f1c5-494f-9b2b-347c636d8ca2",
+        "eventType": "someType",
+        "persistent": "true",
+        "content-type": "application/json;charset=utf-8",
+        "content-length": "298",
     }
 
-    final_headers = publisher._build_final_headers(queue, headers, persistent)
+    expected_final_headers = {
+        "persistent": "true",
+        "tshoot-destination": "/queue/some-destination",
+        "x-dead-letter-routing-key": "DLQ.some-destination",
+        "x-dead-letter-exchange": "",
+        "eventType": "someType",
+        "correlation-id": current_request_id,
+    }
+
+    final_headers = publisher._build_final_headers(queue, raw_headers, persistent)
 
     assert final_headers == expected_final_headers
 
@@ -64,11 +84,34 @@ def test_should_build_final_headers_with_removal_of_unsafe_headers(mocker):
 def test_should_remove_unsafe_headers():
     publisher = build_publisher("test-publisher")
 
-    ok_headers = {"hello": "world", "eventType": "goal"}
-    unsafe_headers = {"eventType": "goal", "message-id": "remove-me-please"}
+    unsafe_headers = {
+        "subscription": "77625173-42b5-4c62-9c24-1fc4a4668dcc-listener",
+        "destination": "/queue/some-destination",
+        "message-id": "T_77625173-42b5-4c62-9c24-1fc4a4668dcc-listener@@session-jSfP4eyH59eKxHaZDv59Cg@@2",
+        "redelivered": "false",
+        "x-dead-letter-routing-key": "DLQ.some-destination",
+        "x-dead-letter-exchange": "",
+        "tshoot-destination": "/queue/some-destination",
+        "transaction": "11837f0b-f1c5-494f-9b2b-347c636d8ca2",
+        "eventType": "someType",
+        "correlation-id": "6e10903e13ddcde54304883e5df713a5",
+        "persistent": "true",
+        "content-type": "application/json;charset=utf-8",
+        "content-length": "298",
+    }
 
-    assert publisher._remove_unsafe_or_reserved_for_broker_use_headers(ok_headers) == ok_headers
-    assert publisher._remove_unsafe_or_reserved_for_broker_use_headers(unsafe_headers) == {"eventType": "goal"}
+    final_headers = {
+        "persistent": "true",
+        "tshoot-destination": "/queue/some-destination",
+        "x-dead-letter-routing-key": "DLQ.some-destination",
+        "x-dead-letter-exchange": "",
+        "eventType": "someType",
+        "correlation-id": "6e10903e13ddcde54304883e5df713a5",
+    }
+
+    # this test already considers a safe tshoot-destination, x-dead-letter-routing-key as
+    # this internal method is invoked after standard_headers (safe) are imposed to the unsafe_headers
+    assert publisher._remove_unsafe_or_reserved_for_broker_use_headers(unsafe_headers) == final_headers
 
 
 def test_should_build_send_data_for_broker():


### PR DESCRIPTION
# What is being delivered?

## Removal of unsafe headers

In the previous bugfix, only the header `message-id` was removed as it caused problems on RabbitMQ brokers. However, other headers such as `transaction` can also cause silent problems when one publishes to a destination. As a consequence, the following headers have also been removed if supplied by users via `publisher.send()`:

- `transaction`
- `redelivered`
- `subscription`
- `destination`
- `content-length`
- `content-type`

Previously, other headers that were created internally by `django-stomp` such as:

- `tshoot-destination`
- `x-dead-letter-routing-key`
- `x-dead-letter-exchange`

Could be **overwritten by users** if sent on the message headers which could wreak havoc by making dead lettered messages go to unexpected DLQs! 

Now, for safety, these **standard headers** (these generated by `django-stomp` internally) take precedence over the user-supplied headers and therefore will overwrite user headers.

## Major tests refactoring: 1. new helper functions to reduce duplicated code

Some new helper functions for integration tests with the brokers were created and used to reduce some boilerplate code that was repeating over and over:

- method to create a publisher, publish and close the connection;
- method for creating a test listener at a destination and returning the last published message;
- new method for publishing messages without the `correlation-id`headers
- method for obtaining broker metrics from management console without try/catch for RabbitMQ and ActiveMQ

## Major tests refactoring: 2. separation of test callbacks into a new module

The integration tests mixed up tests with a lot of callbacks definitions used in such tests. This PR moved these callbacks to a different module in order to leave the `test_execution.py` module only with the tests without a lot of "pollution" that was caused by the callbacks definitions.

## Major tests refactoring: 3. use of uuid4 suffixes on every integration test

Every test now creates destinations with an `uuid4` suffix at the end of its names. This means that tests can now be run repeatedly without requiring a broker restart.

## Major tests refactoring: 4. some old integration tests "fixes" (improvement)

Some old integration tests were passing but weren't 100% accurate, as some messages remained on the queue without being `acked` because the `ack` failed on them:

- `tests.integration.test_execution.py::test_should_consume_message_and_publish_to_another_queue_using_same_correlation_id`

- `tests.integration.test_execution.py::test_should_consume_message_and_publish_to_another_queue_using_creating_correlation_id`

Now, these have been fixed with `return_listener=True` param which is required to avoid the invocation of `testing_listener.close()` on the **test's main thread** which can prematurely close the connection to the broker and compromise the callback's ACK (callback runs on another thread).