### PR TITLE
refactor(package): removed tests folder from installable package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.3.1] - 2023-08-07
+
+### Changed
+
+- Removed tests folder from package.
+
 ## [5.3.0] - 2023-08-07
 
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="django-stomp",
-    version="5.3.0",
+    version="5.3.1",
     description="A simple implementation of STOMP with Django",
     long_description=README,
     long_description_content_type="text/markdown",
@@ -19,7 +19,7 @@ setup(
     author_email="Ricardo Baltazar <ricardobchaves6@gmail.com>, Willian Antunes <willian.lima.antunes@gmail.com>",
     license="MIT",
     url="https://github.com/juntossomosmais/django-stomp",
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests","tests.*")),
     install_requires=["request-id-django-log==0.1.1", "stomp.py~=8.0", "tenacity~=8.0"],
     classifiers=[
         "Programming Language :: Python",


### PR DESCRIPTION
## What is being delivered?

- Excluded tests folder from `find_packages`

## What impacts?

- Removes tests from installation, which was conflicting with other tests folder packages.
